### PR TITLE
Potential fix for code scanning alert no. 11: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -37,4 +37,3 @@ jobs:
           command: "update"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/11](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/11)

To fix the problem, we need to remove the use of `toJson(secrets)` and explicitly pass only the secrets required by the workflow. In this case, the workflow appears to use the `GH_PAT` secret, so we should pass only that secret to the environment. This ensures that the workflow adheres to the principle of least privilege and minimizes the risk of exposing unnecessary secrets.

The changes will involve:
1. Removing the `SECRETS_CONTEXT` environment variable that uses `toJson(secrets)`.
2. Ensuring that only the `GH_PAT` secret is passed to the environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
