### PR TITLE
Potential fix for code scanning alert no. 10: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -44,7 +44,6 @@ jobs:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@v1.40.1
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/10](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/10)

To fix the problem, we should replace the broad usage of `toJson(secrets)` on line 47 with specific references to only the secrets required by the workflow or the called action. Identify which secrets are strictly necessary for the step named "Update response time" (usually that is only `GH_PAT`, already set), and pass only those. If a contextual/environment value is needed, set it explicitly with only whitelisted secrets.  

Change in `.github/workflows/setup.yml`:
- Remove or replace the line `SECRETS_CONTEXT: ${{ toJson(secrets) }}` on line 47.  
- Add explicit secret references (if needed), or simply remove this line if the action functions correctly without it.  
No new imports or additional code is necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
