### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -23,6 +23,8 @@ on:
   workflow_dispatch:
 jobs:
   release:
+    permissions:
+      contents: read
     name: Check status
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/8](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/8)

To address the issue, add a `permissions` block to the `release` job (or optionally at the workflow level if all jobs require the same permissions). The minimal starting point is `contents: read`, which grants read-only access to repository contents, enough for most monitoring and status checks. If the workflow actually needs to write to issues, pull requests, etc., you can expand specific keys (`issues: write`, `pull-requests: write`). For now, only specify `contents: read` for least privilege.

**How to fix:**  
Edit `.github/workflows/uptime.yml`. Under the `release:` job definition (after line 25), add the `permissions:` block with `contents: read`.

**Detailed fix:**  
Insert:
```yaml
permissions:
  contents: read
```
above line 26, so the job contains:
```yaml
release:
  permissions:
    contents: read
  name: Check status
  runs-on: ubuntu-latest
  ...
```
No imports or methods are relevant, just a YAML key addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
