### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -24,6 +24,8 @@ on:
 jobs:
   release:
     name: Generate graphs
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/1](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/1)

To fix the problem, we should explicitly specify the `permissions` required for the job to execute, following the least privilege principle. The most direct fix is to add a `permissions` key to the `release` job in the workflow YAML file, setting it to at least `contents: read`, unless more access is needed (e.g., `contents: write` if the workflow pushes changes, but the minimal recommendation is `contents: read`). This change should be made under the `release` job, at the same indentation level as `name` and `runs-on`. No imports or code definitions are needed since this change is within a YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
