### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -15,6 +15,8 @@
 
 
 name: Setup CI
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/2](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/2)

To fix this problem, explicitly add a `permissions` block to `.github/workflows/setup.yml`. This can be added at the workflow root (top-level), so it applies to all jobs unless they explicitly override it. As a starting point following the least-privilege principle, set `contents: read`; if some steps require more permissions (such as pages deployment or workflow dispatch), escalate only those permissions as necessary at the job (or step) level, but the core fix is to add the global block. The edit should be made near the top of the file after the `name:` field and before `on:` for clarity and adherence to YAML syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
