### PR TITLE
Potential fix for code scanning alert no. 11: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -37,4 +37,4 @@ jobs:
           command: "update"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/11](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/11)

In general, the fix is to stop passing the entire `secrets` context into the workflow and instead only expose specific secrets that are actually needed by the action or script. That means removing `toJson(secrets)` and replacing it with explicit references such as `${{ secrets.GH_PAT }}` or other specific secret names, or simply omitting it if not used.

For this particular workflow, the only secret clearly required is `GH_PAT`, which is already individually passed as `GH_PAT: ${{ secrets.GH_PAT || github.token }}`. There is no indication that `SECRETS_CONTEXT` is needed by `upptime/uptime-monitor@v1.41.0`. Therefore, the safest and simplest change that preserves behavior is to remove the `SECRETS_CONTEXT` environment variable entirely from the `Check endpoint status` step. No other changes are needed: the checkout step and `GH_PAT` env remain as they are, and no imports or additional methods are required because this is a YAML workflow file.

Concretely:
- Edit `.github/workflows/uptime.yml`.
- In the `Check endpoint status` step’s `env:` section, delete the line `SECRETS_CONTEXT: ${{ toJson(secrets) }}`.
- Leave all other lines unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
