### PR TITLE
Potential fix for code scanning alert no. 9: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -37,4 +37,3 @@ jobs:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/9](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/9)

In general, the fix is to stop passing the entire `secrets` context into the workflow and instead pass only the specific secrets that are actually needed. That means removing `toJson(secrets)` and, if the action requires some secrets, supplying them individually as named environment variables or inputs (e.g., `GH_PAT`, `API_KEY`, etc.).

For this workflow, the clear overexposure comes from the `SECRETS_CONTEXT` environment variable in the `Update response time` step:

```yaml
env:
  GH_PAT: ${{ secrets.GH_PAT || github.token }}
  SECRETS_CONTEXT: ${{ toJson(secrets) }}
```

The safest, least intrusive fix—without altering existing functionality of the rest of the workflow—is to remove the `SECRETS_CONTEXT` environment variable entirely, leaving only the already-present `GH_PAT`. The workflow already provides `GH_PAT` both to `actions/checkout` and as an environment variable to `upptime/uptime-monitor`, so the action has at least one credential; if the action actually depended on `SECRETS_CONTEXT`, the original template would be questionable from a security standpoint, but we must not redesign the action internals here. Therefore:

- Edit `.github/workflows/response-time.yml`.
- In the `Update response time` step, delete the line defining `SECRETS_CONTEXT`.
- Keep all other lines unchanged.

No additional imports or methods are needed; this is purely a YAML environment configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
