### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -15,6 +15,8 @@
 
 
 name: Uptime CI
+permissions:
+  contents: write
 on:
   schedule:
     - cron: "*/5 * * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/12](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/12)

To fix the issue, add an explicit `permissions:` block that scopes `GITHUB_TOKEN` to the minimum required access. Since this Upptime workflow updates status files and likely commits them back to the repo, it needs `contents: write`. It does not appear to need other scopes like `issues`, `pull-requests`, or `actions`, so we can omit them.

The cleanest and least-invasive fix is to add a workflow-level `permissions:` section under the `name:` field (around line 17), so it applies to all jobs in this workflow. No other functional changes are required; the `actions/checkout` and `upptime/uptime-monitor` steps will continue to use the same token, but now with explicitly constrained permissions.

Concretely:
- Edit `.github/workflows/uptime.yml`.
- After line 17 (`name: Uptime CI`), insert:

  ```yaml
  permissions:
    contents: write
  ```

- Leave the rest of the workflow unchanged.

No additional imports, methods, or definitions are needed because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
