### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -25,6 +25,8 @@ jobs:
   release:
     name: Check status
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/14](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/14)

In general, the fix is to explicitly declare `permissions` for the workflow or individual jobs, granting only the scopes needed. This overrides the potentially broad repository/organization defaults for the `GITHUB_TOKEN`. For this workflow, the job needs to be able to read and write repository contents so that Upptime can commit and push response-time updates. It does not obviously need other scopes (issues, pull requests, etc.), so we can set `permissions: contents: write` at the job level. That satisfies CodeQL (since `contents` is explicitly scoped) and adheres to least privilege for the known behavior.

The single best fix with minimal functional change is to add a `permissions` block under the `release` job definition (after `runs-on: ubuntu-latest` is a conventional place), setting `contents: write`. This keeps everything else intact: the checkout step still uses the token as before, and Upptime continues to push updates. Concretely, in `.github/workflows/response-time.yml`, between lines 27 and 28, add:

```yaml
    permissions:
      contents: write
```

No imports or external definitions are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
