### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,6 +15,9 @@
 
 
 name: Updates CI
+permissions:
+  contents: write
+  pull-requests: write
 on:
   schedule:
     - cron: "0 3 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/7](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/7)

To fix the problem, explicitly declare a `permissions` block for the workflow or at least for the `release` job so that the `GITHUB_TOKEN` does not inherit broad default permissions. Since this workflow is responsible for deploying updates (likely committing changes and possibly opening PRs), it needs write permission to repository contents and possibly to pull requests, but it does not need full administrative rights.

The single best fix with minimal functional impact is to add a workflow-level `permissions` block near the top, after `name: Updates CI`, granting `contents: write` and `pull-requests: write`. This follows the principle of least privilege for a code-update workflow and will apply to all jobs (currently only `release`) without changing any steps. No imports or external methods are needed, only YAML edits in `.github/workflows/updates.yml`.

Concretely:
- Edit `.github/workflows/updates.yml`.
- Insert:

```yaml
permissions:
  contents: write
  pull-requests: write
```

between the existing `name: Updates CI` line and the `on:` block. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
