### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [static_site]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Build and deploy site


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/6](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/6)

To fix the problem, explicitly declare a `permissions:` block for the workflow so that the GITHUB_TOKEN has only the minimal required privileges. Since this job checks out the repo and then deploys to GitHub Pages via `peaceiris/actions-gh-pages`, it requires write access to repository contents to push to the `gh-pages` (or similar) branch. The minimal safe configuration here is to set `contents: write`. Because there is only a single job and no other jobs shown, the simplest approach is to add a top-level `permissions:` block, which will apply to all jobs in the workflow.

Concretely, in `.github/workflows/site.yml`, add a new block:

```yaml
permissions:
  contents: write
```

between the `on:` block (lines 18–23) and the `jobs:` block (line 24). This does not change any of the existing steps’ behavior but ensures the GITHUB_TOKEN is no longer implicitly over-privileged and is clearly documented as having only the permissions needed to build and deploy the site.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
