### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -15,6 +15,8 @@
 
 
 name: Update Template CI
+permissions:
+  contents: write
 on:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/5](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/5)

To fix the problem, explicitly set `permissions` so the workflow does not rely on repository defaults. We want least privilege while still allowing the job to function. This workflow updates templates via commits to the repository, so it needs to be able to write repository contents. Those writes are typically done via `GH_PAT`, but the safest and simplest explicit configuration (and compatible with existing behavior) is to give `GITHUB_TOKEN` `contents: write` at the workflow level, rather than leaving it implicit.

Best fix without changing functionality:

- Add a root‑level `permissions:` block just under `name: Update Template CI`.
- Set `contents: write` so the workflow can still push changes via `GITHUB_TOKEN` if needed.
- We don’t see evidence of other scopes (issues, pull‑requests, etc.) being required in the snippet, so we do not grant them.

Concretely:

- Edit `.github/workflows/update-template.yml`.
- After line 17 (`name: Update Template CI`), insert:

  ```yml
  permissions:
    contents: write
  ```

No imports or additional definitions are needed for this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
