### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -25,6 +25,8 @@ jobs:
   release:
     name: Generate README
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/4](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/4)

In general, the fix is to explicitly declare the minimal required `permissions` for the workflow or individual jobs so that the implicit GITHUB_TOKEN does not default to broad repository permissions. For a summary/README generation job that updates repository contents, the main required permission is `contents: write`; no other scopes (issues, pull-requests, etc.) are needed based on the snippet shown.

The best targeted fix without changing functionality is to add a `permissions` block to the `release` job. This localizes the change to this workflow and ensures only this job receives the declared permissions. Since the job checks out the repo and likely pushes README updates, we should set `contents: write`. We do not need to adjust steps or tokens, only add the permissions stanza under `jobs.release` (same indentation as `runs-on`). Concretely, in `.github/workflows/summary.yml`, add:

```yaml
jobs:
  release:
    name: Generate README
    runs-on: ubuntu-latest
    permissions:
      contents: write
```

with correct indentation, so CodeQL recognizes that the job now has explicit, least-privilege permissions for GITHUB_TOKEN.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
