### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -15,6 +15,8 @@
 
 
 name: Setup CI
+permissions:
+  contents: write
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/2](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow (at the top level or at the job level) so that the default `GITHUB_TOKEN` permissions are restricted to only those scopes actually needed. For a workflow that commits changes and deploys to GitHub Pages, the key requirement is write access to repository contents, and possibly to pages, but since deployment here is done via an action using `github_token`, the primary need is `contents: write`. We do not need broader scopes like `actions`, `issues`, or `pull-requests`.

The single best minimal change, without altering existing functionality, is to add a workflow-level `permissions` block right under the `name: Setup CI` line. This will apply to the `release` job, which uses `github.token` as a fallback when `secrets.GH_PAT` is not provided, while keeping the rest of the configuration intact. We will set:

```yaml
permissions:
  contents: write
```

This allows the workflow to commit, push, and deploy via `GITHUB_TOKEN` when used, but prevents it from having unnecessary access to other resources. No new imports or dependencies are needed; this is entirely a YAML configuration change within `.github/workflows/setup.yml`.

Concretely:
- Edit `.github/workflows/setup.yml`.
- Insert the `permissions` block between line 17 (`name: Setup CI`) and line 18 (`on:`), keeping indentation consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
