### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -25,6 +25,8 @@ jobs:
   release:
     name: Generate graphs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/1](https://github.com/SeanStaffiery/status.seanstaffiery.com/security/code-scanning/1)

Generally, to fix this issue you explicitly declare GitHub token permissions at the workflow or job level, granting only the minimal scopes required (e.g., `contents: read` or, if pushes are needed, `contents: write`). This prevents the workflow from inheriting broad organization or repository defaults.

For this specific workflow, the minimal and safest change without altering existing behavior is to add a `permissions:` block to the `release` job. Upptime’s “graphs” command typically reads repository contents and pushes generated artifacts; since the workflow already uses a PAT and `github.token` fallback, we should assume it may still rely on `GITHUB_TOKEN` for repository operations. To avoid breaking functionality, we grant `contents: write` at the job level rather than overly restricting it to `read`. This satisfies CodeQL’s requirement (explicit permissions) while keeping behavior intact.

Concretely:
- Edit `.github/workflows/graphs.yml`.
- Within the `jobs:` → `release:` job, add a `permissions:` mapping at the same indentation level as `runs-on:`, before `steps:`.
- Set `contents: write` to explicitly allow repository content modifications if needed.

No additional methods, imports, or definitions are required for this YAML-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
